### PR TITLE
Fix VBO and Tessellator byte buffer order

### DIFF
--- a/src/pw/knx/feather/structures/VBO.java
+++ b/src/pw/knx/feather/structures/VBO.java
@@ -4,6 +4,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 
 import static pw.knx.feather.Feather.FEATHER;
@@ -77,7 +78,7 @@ public class VBO {
 	 */
 	public VBO compile(float... points) {
 		if (points != null && points.length > 0) {
-			final FloatBuffer buffer = ByteBuffer.allocateDirect(points.length * 4).asFloatBuffer();
+			final FloatBuffer buffer = ByteBuffer.allocateDirect(points.length * 4).order(ByteOrder.nativeOrder()).asFloatBuffer();
 			buffer.put(points).flip();
 			return this.compile(buffer);
 		}

--- a/src/pw/knx/feather/tessellate/BasicTess.java
+++ b/src/pw/knx/feather/tessellate/BasicTess.java
@@ -3,6 +3,7 @@ package pw.knx.feather.tessellate;
 import org.lwjgl.opengl.GL11;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 
@@ -71,7 +72,7 @@ public class BasicTess implements Tessellator {
 		 * takes up in the buffer, since each vertex stores color and texture as well. */
 		capacity *= 6;
 		this.raw = new int[capacity];
-		this.buffer = ByteBuffer.allocateDirect(capacity * 4); // 4 bytes in an integer!
+		this.buffer = ByteBuffer.allocateDirect(capacity * 4).order(ByteOrder.nativeOrder()); // 4 bytes in an integer!
 		this.fBuffer = this.buffer.asFloatBuffer();
 		this.iBuffer = this.buffer.asIntBuffer();
 	}

--- a/src/pw/knx/feather/tessellate/ExpandingTess.java
+++ b/src/pw/knx/feather/tessellate/ExpandingTess.java
@@ -1,6 +1,7 @@
 package pw.knx.feather.tessellate;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * An automatically resizing implementation of the Tessellator interface.
@@ -58,7 +59,7 @@ public class ExpandingTess extends BasicTess {
 			final int[] newBuffer = new int[capacity];          // allocate the new data
 			System.arraycopy(raw, 0, newBuffer, 0, raw.length); // transfer the data from the old array to the new array
 			raw = newBuffer;                                    // replace the array
-			buffer = ByteBuffer.allocateDirect(capacity * 4);       // allocate a new corresponding ByteBuffer
+			buffer = ByteBuffer.allocateDirect(capacity * 4).order(ByteOrder.nativeOrder());       // allocate a new corresponding ByteBuffer
 			iBuffer = buffer.asIntBuffer();
 			fBuffer = buffer.asFloatBuffer();
 		}


### PR DESCRIPTION
When removing the feather instance buffer allocation, the buffer order wasn't reset to "native".