### PR TITLE
StackOverflowError caused by bad resetting of dirty flags

### DIFF
--- a/src/main/java/pw/knx/feather/structures/Color.java
+++ b/src/main/java/pw/knx/feather/structures/Color.java
@@ -351,6 +351,7 @@ public class Color {
 	 * @return This color object, freshly set
 	 */
 	public Color hsb(float hue, float saturation, float brightness) {
+		this.updateHSB = false;
 		return hue(hue).saturation(saturation).brightness(brightness);
 	}
 
@@ -365,6 +366,7 @@ public class Color {
 	 * @return This color object, freshly set
 	 */
 	public Color rgb(float red, float green, float blue) {
+	    this.updateRGB = false;
 		return red(red).green(green).blue(blue);
 	}
 
@@ -379,6 +381,7 @@ public class Color {
 	 * @return This color object, freshly set
 	 */
 	public Color rgb(int red, int green, int blue) {
+	    this.updateRGBInts = false;
 		return red(red).green(green).blue(blue);
 	}
 
@@ -414,6 +417,7 @@ public class Color {
 		int alpha = format.getAlphaInt(hex);
 		if (alpha != 0)
 			alpha(alpha);
+		this.updateRGBInts = false;
 		return red(format.getRedInt(hex)).green(format.getGreenInt(hex)).blue(format.getBlueInt(hex));
 	}
 


### PR DESCRIPTION
I've created the following test to demonstrate this issue:
```java
Color color = Color.fromHex(0xFFFFFFFF);
print(color);

// Make HSB dirty, then set ARGB using hex
color.hsb(0.3F, 1.0F, 1.0F);
print(color);
color.hex(0xFF000000);
print(color);

// Make HSB dirty, then set RGB using rgb (int)
color.hsb(0.7F, 0.1F, 1.0F);
print(color);
color.rgb(255, 255, 0);
print(color);

// Make HSB dirty, then set RGB using rgb (float)
color.hsb(0.7F, 0.1F, 1.0F);
print(color);
color.rgb(1.0F, 0.5F, 0.5F);
print(color);

// Make HSB dirty, then set RGB individually
color.hue(0.1F).saturation(0.3F).brightness(0.1F);
print(color);
color.red(1.0F).green(0.3F).blue(0.4F);
print(color);

// Make RGB dirty, then set HSB individually
color.red(0.1F).green(0.6F).blue(0.3F);
print(color);
color.hue(0.8F).saturation(0.3F).brightness(0.9F);
print(color);
```
```
void print(Color color) {
    System.out.println(Integer.toHexString(color.getHex()));
}
```

This should be valid code. However, when it is run, we get a ``StackOverflowError``!

```
at pw.knx.feather.structures.Color.getHue(Color.java:608)
at pw.knx.feather.structures.Color.updateRGBInts(Color.java:739)
at pw.knx.feather.structures.Color.getRedInt(Color.java:656)
at pw.knx.feather.structures.Color.updateHSB(Color.java:716)
...
```

I believe the problem arises when the "dirty" flags are not cleared on the full component set passes (``Color#hsb(float, float, float)``, ``Color#hex(int)``, ``Color#rgb(int, int, int)``, ``Color#rgb(float, float, float)``.

The changes that I have made reset the dirty flags for each of these methods, and running the test again gives an expected result:

```
ffffffff
ff33ff00
ff000000
ffe6ffff
ffffff00
ffaea1e6
ffff7f7f
ff1a1612
ffff4c66
ff19994c
ffd8a1e6
```